### PR TITLE
data: correctly set homepage URL

### DIFF
--- a/data/com.oyajun.ColorCode.metainfo.xml.in
+++ b/data/com.oyajun.ColorCode.metainfo.xml.in
@@ -12,7 +12,7 @@
   <developer id="com.oyajun">
     <name>oyajun</name>
   </developer>
-  <url type="homepage">https://https://github.com/oyajun/color-code</url>
+  <url type="homepage">https://github.com/oyajun/color-code</url>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/oyajun/color-code/main/data/screenshots/screenshot1.png</image>


### PR DESCRIPTION
The Flathub page does not link back to the GitHub repo correctly, probably due to the duplicated URL scheme in the homepage.