### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -8,7 +8,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: bilelmoussaoui/flatpak-github-actions:gnome-nightly
       options: --privileged
     strategy:
       matrix:

--- a/com.oyajun.ColorCode.json
+++ b/com.oyajun.ColorCode.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.oyajun.ColorCode",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "master",
     "sdk" : "org.gnome.Sdk",
     "command" : "color-code",
     "finish-args" : [
@@ -34,7 +34,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-                    "tag" : "v0.12.0"
+                    "tag" : "v0.14.0"
                 }
             ]
         },


### PR DESCRIPTION
This updates the runtime to `master` to gain access to experimental widgets. 

The `master` branch can be obtained from the GNOME Nightly Flatpak remote: https://nightly.gnome.org/